### PR TITLE
HOTFIX: Removed case when variables were uninitialized.

### DIFF
--- a/Heaps/BHeap.h
+++ b/Heaps/BHeap.h
@@ -112,7 +112,7 @@ void ds::BinaryHeap<T>::bubbleup(size_t in)
 template <typename T>
 void ds::BinaryHeap<T>::bubbledown(size_t in)
 {
-	size_t child, child1;
+	size_t child = 0, child1 = 0;
 	if (rightexist(in))
 		child1 = right(in);
 	if (leftexist(in))


### PR DESCRIPTION
# Description

HOTFIX: Removed case when variables were uninitialized. Now compiler generates 0 warnings.

References #5

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
